### PR TITLE
bounded lookup field successful!

### DIFF
--- a/CreateFromLookupField/ControlManifest.Input.xml
+++ b/CreateFromLookupField/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="chrizgl" constructor="CreateFromLookupField" version="3.0.2" display-name-key="CreateFromLookupField" description-key="CreateFromLookupField description" control-type="standard">
+  <control namespace="chrizgl" constructor="CreateFromLookupField" version="4.0.0" display-name-key="CreateFromLookupField" description-key="CreateFromLookupField description" control-type="standard">
     <external-service-usage enabled="true">
       <!--UNCOMMENT TO ADD EXTERNAL DOMAINS
       <domain></domain>
@@ -8,12 +8,8 @@
       -->
     </external-service-usage>
     <!-- property node identifies a specific, configurable piece of data that the control expects from CDS -->
-    <property name="searchInputField" display-name-key="Search_Input_Field" description-key="Text field to enter lookUp value" of-type-group="strings" usage="bound" required="true" />
-    <property name="sourceEntityId" display-name-key="Source_Entity_Id" description-key="The id of the current (source) record." of-type="SingleLine.Text" usage="input" required="true" />
+    <property name="lookupField" display-name-key="lookupField_Display_Key" description-key="lookupField_Desc_Key" of-type="Lookup.Simple" usage="bound" required="true" />
     <property name="configJSON" display-name-key="ConfigJSON" description-key="ConfigJSON" of-type="Multiple" usage="input" required="true" />
-    <type-group name="strings">
-      <type>SingleLine.Text</type>
-    </type-group>
     <resources>
       <code path="index.ts" order="1"/>
       <!-- UNCOMMENT TO ADD MORE RESOURCES

--- a/CreateFromLookupField/components/LookupFieldApp.tsx
+++ b/CreateFromLookupField/components/LookupFieldApp.tsx
@@ -20,25 +20,20 @@ const CreateFromLookupApp = (props: iCreateFromLookupProps): JSX.Element => {
     const [inputValue, setInputValue] = useState('');
     const [validInputState, setValidInputState] = useState(false);
     const [searchState, setSearchState] = useState<iCreateFromLookupState>({
-        currentValue: '',
+        // currentValue: '',
         overlayHidden: true,
         iconBackground: 'transparent',
     });
     const [createEnabledState, setCreateEnabledState] = useState(false);
     const [createState, setCreateState] = useState<iCreateFromLookupState>({
-        currentValue: '',
+        // currentValue: '',
         overlayHidden: true,
         iconBackground: 'transparent',
     });
     const onInputKey: InputProps['onKeyUp'] = (key) => {
         if (key.key === 'Enter') {
             onClickSearchRequest();
-            onRequest();
         }
-    };
-
-    const onRequest = () => {
-        props.onRequest(inputValue);
     };
     //
     // noch habe ich eine eigene Funktionen für Search und Create, eventuell ginge hier ne Klasse und instanzieren?

--- a/CreateFromLookupField/index.ts
+++ b/CreateFromLookupField/index.ts
@@ -14,7 +14,6 @@ export class CreateFromLookupField implements ComponentFramework.StandardControl
     private _targetEntityName: string;
     private _isCreateEnabled: boolean;
     private _config: any;
-    private _writeToField: string;
     private _lookupValue: ComponentFramework.LookupValue[] = [];
 
     constructor() {}
@@ -34,14 +33,11 @@ export class CreateFromLookupField implements ComponentFramework.StandardControl
     }
 
     public updateView(context: ComponentFramework.Context<IInputs>): void {
-        const inputValue = context.parameters.searchInputField.raw || '';
         const props: iCreateFromLookupProps = {
-            input: inputValue,
             utils: context.utils,
             isDisabled: false,
             isCreateEnabled: this._isCreateEnabled,
             currentValue: this._currentValue,
-            onRequest: this.onChange,
             onSearchRequest: this.retrieveRecords.bind(this),
             onCreateRequest: this.createRecord.bind(this),
         };
@@ -50,21 +46,16 @@ export class CreateFromLookupField implements ComponentFramework.StandardControl
     }
 
     public getOutputs(): IOutputs {
-        return { searchInputField: this._writeToField };
+        return { lookupField: this._lookupValue };
     }
 
     public destroy(): void {
         this._root.unmount();
     }
 
-    private onChange = (value: string) => {
-        this._currentValue = value;
-    };
-
-    private onSetLookupField = () => {
-        const tmpLookupField = Xrm.Page.getAttribute(this._config.sourceLookupField);
-        tmpLookupField.setValue(this._lookupValue);
-        console.log(`Lookup field updated with ${this._lookupValue[0].name}`);
+    private onChange = () => {
+        // this._currentValue = value;
+        this._notifyOutputChanged();
     };
 
     private async createRecord(value: string): Promise<boolean> {
@@ -92,7 +83,7 @@ export class CreateFromLookupField implements ComponentFramework.StandardControl
                 name: value,
                 entityType: this._targetEntityName,
             };
-            this.onSetLookupField();
+            this.onChange();
         } else {
             createdRecord = false;
         }
@@ -119,7 +110,7 @@ export class CreateFromLookupField implements ComponentFramework.StandardControl
                 name: value,
                 entityType: this._targetEntityName,
             };
-            this.onSetLookupField();
+            this.onChange();
             foundRecords = true;
         } else {
             foundRecords = false;

--- a/CreateFromLookupField/interfaces/iCreateFromLookupProps.tsx
+++ b/CreateFromLookupField/interfaces/iCreateFromLookupProps.tsx
@@ -1,12 +1,10 @@
 import { IInputs } from '../generated/ManifestTypes';
 
 export interface iCreateFromLookupProps {
-    input: string | undefined;
     utils: ComponentFramework.Utility;
     isDisabled: boolean;
     currentValue: string;
     isCreateEnabled: boolean;
-    onRequest: (text: string) => void;
     onSearchRequest: (text: string) => Promise<boolean>;
     onCreateRequest: (text: string) => Promise<boolean>;
 }

--- a/CreateFromLookupField/interfaces/iCreateFromLookupState.tsx
+++ b/CreateFromLookupField/interfaces/iCreateFromLookupState.tsx
@@ -1,5 +1,4 @@
 export interface iCreateFromLookupState {
-    currentValue: string;
     overlayHidden: boolean;
     iconBackground: string;
 }


### PR DESCRIPTION
This version does without the dummy lookup field (text field).
Instead, the real lookup field is used.
Changes are saved as intended via the getOutputs() method.
The unspported "Xrm.Page" variant is omitted!